### PR TITLE
Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.2</version>
+            <version>2.9.8</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Addresses CVEs
  2018-19360,
  2018-19361,
  2018-19362,
  2018-14719,
  2018-14720,
  2018-14721,
  2018-14718,
  2018-17485,
  2018-7489